### PR TITLE
RunQemuPXE: always copy ldlinux.c32 and libcom32.c32

### DIFF
--- a/Kernel/rundir/RunQemuPXE
+++ b/Kernel/rundir/RunQemuPXE
@@ -14,7 +14,7 @@ PXELINUX_DIR=/usr/lib/syslinux/
 rm -rf .pxe/
 mkdir -p .pxe/pxelinux.cfg
 if [ -e ${PXELINUX_DIR}pxelinux.0 ]; then
-	cp ${PXELINUX_DIR}pxelinux.0 ${PXELINUX_DIR}mboot.c32 .pxe/
+	cp ${PXELINUX_DIR}{pxelinux.0,mboot.c32,ldlinux.c32,libcom32.c32} .pxe/
 else
 	cp /usr/lib/PXELINUX/pxelinux.0 .pxe/
 	cp /usr/lib/syslinux/modules/bios/mboot.c32 .pxe/


### PR DESCRIPTION
Presumably both sides of this if condition should be copying the same files.

For Arch Linux, I also changed `PXELINUX_DIR=/usr/lib/syslinux/` to `PXELINUX_DIR=/usr/lib/syslinux/bios/`.

Hopefully there's some more portable solution here, but I don't know what...